### PR TITLE
Apply Skull Texture through the API instead of reflection

### DIFF
--- a/core-paper/src/main/kotlin/de/miraculixx/mcore/gui/items/ItemExtensions.kt
+++ b/core-paper/src/main/kotlin/de/miraculixx/mcore/gui/items/ItemExtensions.kt
@@ -1,25 +1,14 @@
 package de.miraculixx.mcore.gui.items
 
 
-import com.mojang.authlib.GameProfile
-import com.mojang.authlib.properties.Property
-import de.miraculixx.mvanilla.messages.*
+import com.destroystokyo.paper.profile.ProfileProperty
+import org.bukkit.Bukkit
 import org.bukkit.inventory.meta.SkullMeta
-import java.lang.reflect.Field
 import java.util.*
 
 fun SkullMeta.skullTexture(base64: String, uuid: UUID = UUID.randomUUID()): SkullMeta {
-    val profile = GameProfile(uuid, "")
-    profile.properties.put("textures", Property("textures", base64))
-    val profileField: Field?
-    try {
-        profileField = javaClass.getDeclaredField("profile")
-        profileField.isAccessible = true
-        profileField[this] = profile
-    } catch (e: Exception) {
-        e.printStackTrace()
-        consoleAudience.sendMessage(prefix + cmp("Head Builder failed to apply Base64 Code to Skull!", cError))
-        consoleAudience.sendMessage(prefix + cmp("Code: ", cError) + cmp(base64))
-    }
+    val profile = Bukkit.createProfile(uuid)
+    profile.setProperty(ProfileProperty("textures", base64))
+    playerProfile = profile
     return this
 }


### PR DESCRIPTION
Paper now nags when using reflection to set a Skull Texture and spamms the console with it. This applies the textures using the new PlayerProfile API

![Example of Paper nagging me to death](https://github.com/MUtils-MC/MUtils/assets/82610361/d96b7e72-b32d-4e6b-810f-436973493969)
